### PR TITLE
Do not add margin-right to row if gutter = 0

### DIFF
--- a/src/row.js
+++ b/src/row.js
@@ -9,8 +9,11 @@ export default (decl, margin, display) => {
 
   let declNew = [
     postcss.decl({ prop: 'clear', value: 'both' }),
-    postcss.decl({ prop: 'margin-right', value: `-${margin}` }),
   ];
+
+  if (margin !== '0') {
+    declNew.push(postcss.decl({ prop: 'margin-right', value: `-${margin}` }));
+  }
 
   if (display === 'flex') {
     declNew = declNew.concat([

--- a/test/01.js
+++ b/test/01.js
@@ -14,6 +14,11 @@ const tests = {
 .blob-flex {
   gf: blob 1/2 1.5rem;
 }
+
+.row-with-margin {
+  margin: 0 auto;
+  gf: row 0 float;
+}
 `,
   output: `.row-float {
   clear: both;
@@ -52,6 +57,17 @@ const tests = {
   margin-right: 1.5rem;
   margin-bottom: 1.5rem;
   flex: 0 1 calc(50% - 1.5rem);
+}
+
+.row-with-margin {
+  margin: 0 auto;
+  clear: both;
+}
+
+.row-with-margin::after {
+  content: "";
+  display: table;
+  clear: both;
 }
 `,
 };


### PR DESCRIPTION
At the moment a margin-right is always added to a row even if gutter = 0. This may break previously defined properties like "margin: 0 auto".

Thank you for postcss-grid-fluid 👍 
